### PR TITLE
Implement upserts

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -1,0 +1,32 @@
+// NOTE: This function removes any props containing $.
+//
+export function clean(what: string[] | { [prop: string]: any }): string[] | { [prop: string]: any } {
+  if (Array.isArray(what)) {
+    return cleanArray(what)
+  }
+
+  return cleanObject(what)
+
+
+  function cleanArray(ary: string[]): string[] {
+    return ary.filter(x => !isPrivateProp(x))
+  }
+
+  function cleanObject(obj: { [prop: string]: any }): { [prop: string]: any } {
+    const out: { [prop: string]: any } = {}
+
+    const public_props = Object.getOwnPropertyNames(what)
+      .filter(p => !isPrivateProp(p))
+
+    for (const p of public_props) {
+      out[p] = obj[p]
+    }
+
+    return out
+  }
+
+  function isPrivateProp(prop: string) : boolean {
+    return prop.includes('$')
+  }
+}
+

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -164,9 +164,9 @@ function mem_store(options: any) {
               }
 
 
-              const public_entdata = msg.ent.data$(false)
               const collection = entmap[base][name]
               const docs = Object.values(collection)
+              const public_entdata = msg.ent.data$(false)
 
 
               const doc_to_update = docs.find((doc: any) => {

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -110,18 +110,18 @@ function mem_store(options: any) {
 
         return upsertIfRequested(msg, function (err: Error, ctx: UpsertIfRequestedContext) {
           if (err) {
-            return reply(err);
+            return reply(err)
           }
 
-          const { did_upsert } = ctx;
+          const { did_upsert } = ctx
 
           if (did_upsert) {
-            const { out } = ctx;
-            return reply(null, out);
+            const { out } = ctx
+            return reply(null, out)
           }
 
 
-          prev = entmap[base][name][mement.id] = mement;
+          prev = entmap[base][name][mement.id] = mement
 
           seneca.log.debug(function () {
             return [
@@ -129,8 +129,8 @@ function mem_store(options: any) {
               ent.canon$({ string: 1 }),
               mement,
               desc,
-            ];
-          });
+            ]
+          })
 
           return reply(null, ent.make$(prev));
         })
@@ -146,7 +146,7 @@ function mem_store(options: any) {
         function upsertIfRequested(msg: any, reply: UpsertIfRequestedCallback) {
           // This is the query passed to the .save$ method.
           //
-          const query_for_save = msg.q;
+          const query_for_save = msg.q
 
 
           if (isNewEntityBeingCreated(msg) && Array.isArray(query_for_save.upsert$)) {
@@ -161,50 +161,50 @@ function mem_store(options: any) {
               // ```
               // - returns a list of all entities.
               //
-              .filter((p: string) => !isPrivateProp(p));
+              .filter((p: string) => !isPrivateProp(p))
 
 
             if (upsert_on.length > 0) {
-              const qent = msg.ent;
-              const public_entdata = msg.ent.data$(false);
+              const qent = msg.ent
+              const public_entdata = msg.ent.data$(false)
 
               const q = upsert_on.reduce((acc: any, upsert_on_field: string) => {
-                acc[upsert_on_field] = public_entdata[upsert_on_field];
-                return acc;
-              }, {});
+                acc[upsert_on_field] = public_entdata[upsert_on_field]
+                return acc
+              }, {})
 
 
               return listents(seneca, entmap, qent, q, function (err: Error | null, docs_to_update: any[]) {
                 if (err) {
-                  return reply(err);
+                  return reply(err)
                 }
 
-                const ent_data = ent.data$(false);
+                const ent_data = ent.data$(false)
 
                 if (docs_to_update.length > 0) {
-                  const doc = docs_to_update[0];
+                  const doc = docs_to_update[0]
 
                   return doc
                     .data$(public_entdata)
                     .save$((err: Error | null) => {
                     if (err) {
-                      return reply(err);
+                      return reply(err)
                     }
 
                     return reply(null, {
                       did_upsert: true,
                       out: ent.make$(public_entdata)
-                    });
-                  });
+                    })
+                  })
                 }
 
-                return reply(null, { did_upsert: false, out: null });
+                return reply(null, { did_upsert: false, out: null })
               });
             } else {
-              return reply(null, { did_upsert: false, out: null });
+              return reply(null, { did_upsert: false, out: null })
             }
           } else {
-            return reply(null, { did_upsert: false, out: null });
+            return reply(null, { did_upsert: false, out: null })
           }
         }
       }

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -163,16 +163,15 @@ function mem_store(options: any) {
                 return reply(null, { did_upsert: false, out: null })
               }
 
-              const ent = msg.ent
-              const public_entdata = ent.data$(false)
 
+              const public_entdata = msg.ent.data$(false)
               const collection = entmap[base][name]
               const docs = Object.values(collection)
 
+
               const doc_to_update = docs.find((doc: any) => {
-                return upsert_on.every((upsert_on_field: string) => {
-                  return upsert_on_field in public_entdata &&
-                    public_entdata[upsert_on_field] === doc[upsert_on_field]
+                return upsert_on.every((p: string) => {
+                  return p in public_entdata && public_entdata[p] === doc[p]
                 })
               })
 
@@ -181,7 +180,7 @@ function mem_store(options: any) {
               }
 
 
-              return ent.make$(doc_to_update)
+              return msg.ent.make$(doc_to_update)
                 .data$(public_entdata)
                 .save$((err: Error | null, out: any) => {
                   if (err) {

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -1,10 +1,11 @@
 /* Copyright (c) 2010-2020 Richard Rodger and other contributors, MIT License */
 'use strict'
 
-const Assert = require('assert');
+const Assert = require('assert')
+import * as Common from './lib/common'
 
 let internals = {
-  name: 'mem-store',
+  name: 'mem-store'
 }
 
 module.exports = mem_store
@@ -150,18 +151,17 @@ function mem_store(options: any) {
 
 
           if (isNewEntityBeingCreated(msg) && Array.isArray(query_for_save.upsert$)) {
-            const upsert_on = query_for_save.upsert$
-              //
-              // NOTE: Here we are stripping private properties from the
-              // upsert$ fields. That's because the underlying `listents`
-              // helper ignores private properties completely, - in ways
-              // that lead to situations where:
-              // ```
-              //  .list$({ i_am_private_prop$: 'abc' })
-              // ```
-              // - returns a list of all entities.
-              //
-              .filter((p: string) => !isPrivateProp(p))
+            //
+            // NOTE: Here we are stripping private properties from the
+            // upsert$ fields. That's because the underlying `listents`
+            // helper ignores private properties completely, - in ways
+            // that lead to situations where:
+            // ```
+            //  .list$({ i_am_private_prop$: 'abc' })
+            // ```
+            // - returns a list of all entities.
+            //
+            const upsert_on = Common.clean(query_for_save.upsert$)
 
 
             if (upsert_on.length > 0) {
@@ -532,10 +532,5 @@ function listents(seneca: any, entmap: any, qent: any, q: any, done: any) {
 
   // Return the resulting list to the caller.
   done.call(seneca, null, list)
-}
-
-function isPrivateProp(prop: any) : boolean {
-  return typeof prop === 'string' &&
-    (<string> prop).indexOf('$') >= 0;
 }
 

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -1,6 +1,8 @@
 /* Copyright (c) 2010-2020 Richard Rodger and other contributors, MIT License */
 'use strict'
 
+const Assert = require('assert')
+
 let internals = {
   name: 'mem-store',
 }
@@ -148,7 +150,7 @@ function mem_store(options: any) {
           const query_for_save = msg.q;
 
 
-          if (Array.isArray(query_for_save.upsert$)) {
+          if (isNewEntityBeingCreated(msg) && Array.isArray(query_for_save.upsert$)) {
             const upsert_on = query_for_save.upsert$
               //
               // NOTE: Here we are stripping private properties from the
@@ -186,6 +188,8 @@ function mem_store(options: any) {
                       return reply(err);
                     }
 
+                    console.log('OK'); // dbg
+
                     return reply(null, {
                       did_upsert: true,
                       out: ent.list$(public_entdata)
@@ -194,6 +198,8 @@ function mem_store(options: any) {
 
 
                   function updateNextDoc(i: number, cb: (err: Error | null) => any) {
+                    Assert(i >= 0, 'i must be positive');
+
                     if (i >= docs_to_update.length) {
                       return cb(null);
                     }
@@ -263,6 +269,18 @@ function mem_store(options: any) {
             do_save(id, true)
           })
         }
+      }
+
+      function isNewEntityBeingCreated(msg: any) {
+        if (!('ent' in msg)) {
+          // NOTE: This should not happen.
+          //
+          return false;
+        }
+
+        const ent = msg.ent;
+
+        return ent && ent.id === null || ent.id === undefined;
       }
     },
 

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -114,9 +114,9 @@ function mem_store(options: any) {
             return reply(err)
           }
 
-          const { did_upsert } = ctx
+          const { did_update } = ctx
 
-          if (did_upsert) {
+          if (did_update) {
             const { out } = ctx
             return reply(null, out)
           }
@@ -137,7 +137,7 @@ function mem_store(options: any) {
         })
 
 
-        type UpsertIfRequestedContext = { did_upsert: boolean, out?: any }
+        type UpsertIfRequestedContext = { did_update: boolean, out?: any }
 
         type UpsertIfRequestedCallback = (
           err:     Error | null,
@@ -156,11 +156,11 @@ function mem_store(options: any) {
 
             if (upsert_on.length > 0) {
               if (!(base in entmap)) {
-                return reply(null, { did_upsert: false, out: null })
+                return reply(null, { did_update: false, out: null })
               }
 
               if (!(name in entmap[base])) {
-                return reply(null, { did_upsert: false, out: null })
+                return reply(null, { did_update: false, out: null })
               }
 
 
@@ -176,7 +176,7 @@ function mem_store(options: any) {
               })
 
               if (!doc_to_update) {
-                return reply(null, { did_upsert: false, out: null })
+                return reply(null, { did_update: false, out: null })
               }
 
 
@@ -188,15 +188,15 @@ function mem_store(options: any) {
                   }
 
                   return reply(null, {
-                    did_upsert: true,
+                    did_update: true,
                     out
                   })
               })
             } else {
-              return reply(null, { did_upsert: false, out: null })
+              return reply(null, { did_update: false, out: null })
             }
           } else {
-            return reply(null, { did_upsert: false, out: null })
+            return reply(null, { did_update: false, out: null })
           }
         }
       }

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -210,6 +210,12 @@ function mem_store(options: any) {
                           return cb(err);
                         }
 
+                        // NOTE: WARNING: It is intentional that the
+                        // `updateNextDoc` function is invoked asynchronously.
+                        //
+                        // Calling it synchronously may lead to a stack
+                        // overflow, when there's a huge list of matches.
+                        //
                         return process.nextTick(() => updateNextDoc(i + 1, cb));
                       });
                   }

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2010-2020 Richard Rodger and other contributors, MIT License */
 'use strict'
 
-const Assert = require('assert')
+const Assert = require('assert');
 
 let internals = {
   name: 'mem-store',

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -171,7 +171,8 @@ function mem_store(options: any) {
 
               const doc_to_update = docs.find((doc: any) => {
                 return upsert_on.every((upsert_on_field: string) => {
-                  return doc[upsert_on_field] === public_entdata[upsert_on_field]
+                  return upsert_on_field in public_entdata &&
+                    public_entdata[upsert_on_field] === doc[upsert_on_field]
                 })
               })
 

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -78,7 +78,7 @@ function mem_store(options: any) {
       // The actual save logic for saving or
       // creating and then saving the entity.
       function do_save(id?: any, isnew?: boolean) {
-        let mement = ent.data$(true, 'string');
+        let mement = ent.data$(true, 'string')
 
         if (undefined !== id) {
           mement.id = id

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -187,8 +187,6 @@ function mem_store(options: any) {
                       return reply(err);
                     }
 
-                    console.log('OK'); // dbg
-
                     return reply(null, {
                       did_upsert: true,
                       out: ent.list$(public_entdata)

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -1,7 +1,7 @@
 /* Copyright (c) 2010-2020 Richard Rodger and other contributors, MIT License */
 'use strict'
 
-const Assert = require('assert')
+import Assert from 'assert'
 import * as Common from './lib/common'
 
 let internals = {

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -78,9 +78,7 @@ function mem_store(options: any) {
       // The actual save logic for saving or
       // creating and then saving the entity.
       function do_save(id?: any, isnew?: boolean) {
-        const ent_data = ent.data$(true, 'string');
-
-        let mement = ent_data;
+        let mement = ent.data$(true, 'string');
 
         if (undefined !== id) {
           mement.id = id
@@ -149,14 +147,27 @@ function mem_store(options: any) {
 
           if (query_for_save && Array.isArray(query_for_save.upsert$)) {
             if (query_for_save.upsert$.length > 0) {
-              const upsert_on: Array<string> = query_for_save.upsert$
-                .filter((field: string) => field in ent_data);
+              const ent_data = ent.data$(false);
+
+              console.log('ent', ent) // dbg
+              console.log(query_for_save.upsert$) // dbg
+              console.log(ent_data) // dbg
+
+              const upsert_on: Array<string> = query_for_save.upsert$;
 
               const shouldUpdateDoc = (doc: any) => {
-                return upsert_on.every(upsert_on_field =>
-                  upsert_on_field in doc &&
-                    doc[upsert_on_field] === mement[upsert_on_field]);
-              }
+                console.log('upsert on', upsert_on) // dbg
+                console.log('doc', doc) // dbg
+                console.log('mement', mement) // dbg
+
+                return upsert_on.every(upsert_on_field => {
+                  const we_do_not_care_if_a_doc_has_the_field_or_not =
+                    ((upsert_on_field in doc) || !(upsert_on_field in doc));
+
+                  return we_do_not_care_if_a_doc_has_the_field_or_not &&
+                    doc[upsert_on_field] === mement[upsert_on_field];
+                });
+              };
 
               const collection = entmap[base][name] || {};
               const docs = Object.values(collection);

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -179,8 +179,6 @@ function mem_store(options: any) {
                   return reply(err)
                 }
 
-                const ent_data = ent.data$(false)
-
                 if (docs_to_update.length > 0) {
                   const doc = docs_to_update[0]
 

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -68,8 +68,7 @@ function mem_store(options: any) {
       // check if we are in create mode,
       // if we are do a create, otherwise
       // we will do a save instead
-      let create = ent.id == null
-      if (create) {
+      if (isNewEntityBeingCreated(msg)) {
         create_new()
       } else {
         do_save()
@@ -126,7 +125,7 @@ function mem_store(options: any) {
 
           seneca.log.debug(function () {
             return [
-              'save/' + (create ? 'insert' : 'update'),
+              'save/' + (isNewEntityBeingCreated(msg) ? 'insert' : 'update'),
               ent.canon$({ string: 1 }),
               mement,
               desc,
@@ -271,12 +270,9 @@ function mem_store(options: any) {
         }
       }
 
-      function isNewEntityBeingCreated(msg: any) {
-        if (!('ent' in msg)) {
-          // NOTE: This should not happen.
-          //
-          return false;
-        }
+      function isNewEntityBeingCreated(msg: any) : boolean {
+        Assert('ent' in msg, 'msg.ent');
+        Assert(msg.ent, 'msg.ent');
 
         const ent = msg.ent;
 

--- a/mem-store.ts
+++ b/mem-store.ts
@@ -182,43 +182,20 @@ function mem_store(options: any) {
                 const ent_data = ent.data$(false);
 
                 if (docs_to_update.length > 0) {
-                  return updateNextDoc(0, (err: Error | null) => {
+                  const doc = docs_to_update[0];
+
+                  return doc
+                    .data$(public_entdata)
+                    .save$((err: Error | null) => {
                     if (err) {
                       return reply(err);
                     }
 
                     return reply(null, {
                       did_upsert: true,
-                      out: ent.list$(public_entdata)
+                      out: ent.make$(public_entdata)
                     });
                   });
-
-
-                  function updateNextDoc(i: number, cb: (err: Error | null) => any) {
-                    Assert(i >= 0, 'i must be positive');
-
-                    if (i >= docs_to_update.length) {
-                      return cb(null);
-                    }
-
-                    const doc = docs_to_update[i];
-
-                    return doc
-                      .data$(public_entdata)
-                      .save$((err: Error) => {
-                        if (err) {
-                          return cb(err);
-                        }
-
-                        // NOTE: WARNING: It is intentional that the
-                        // `updateNextDoc` function is invoked asynchronously.
-                        //
-                        // Calling it synchronously may lead to a stack
-                        // overflow, when there's a huge list of matches.
-                        //
-                        return process.nextTick(() => updateNextDoc(i + 1, cb));
-                      });
-                  }
                 }
 
                 return reply(null, { did_upsert: false, out: null });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,2440 @@
 {
   "name": "seneca-mem-store",
   "version": "5.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@hapi/code": "^8.0.2",
+        "@hapi/lab": "^24.1.0",
+        "async": "3.2.0",
+        "lab-transform-typescript": "^3.0.1",
+        "prettier": "^2.2.1",
+        "seneca": "^3.23.0",
+        "seneca-entity": "^11.0.0",
+        "seneca-promisify": "^2.0.0",
+        "seneca-store-test": "^3.1.0",
+        "typescript": "^4.1.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
+      "integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.12.5",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/@babel/helper-get-function-arity": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
+      "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.12.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.9.tgz",
+      "integrity": "sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.7.tgz",
+      "integrity": "sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
+      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@hapi/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hapi/boom": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.0.tgz",
+      "integrity": "sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/bossy": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/bossy/-/bossy-5.0.1.tgz",
+      "integrity": "sha512-/HP5KSQ7EGLcnIdmwYj47mKh6f1htos2Dd8QlQjy59k61lENzKgvFbaPa+REQQGGgVQK7QREO55w/Wjkw2dzrQ==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/bourne": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+      "dev": true
+    },
+    "node_modules/@hapi/code": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/code/-/code-8.0.2.tgz",
+      "integrity": "sha512-JG3yfRMU/acl48i14YAwucyf12wtIyyfEJ4PyL/qZxDd3ltjqCVIlZmOSCazxFjtDZTfMx6TLVcDU5XWvP8tNQ==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/eslint-plugin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/eslint-plugin/-/eslint-plugin-5.0.0.tgz",
+      "integrity": "sha512-a3K7cVhxhcN3NJv+UCFeOS8RO+mFtnpgbtkDIPplOdBQoYEuAUCePooZKJuYu07N5z/QjmsSQz83Xx/hHlfJDA==",
+      "dev": true
+    },
+    "node_modules/@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
+      "dev": true
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==",
+      "dev": true
+    },
+    "node_modules/@hapi/joi": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
+      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/address": "^4.0.1",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "node_modules/@hapi/lab": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/lab/-/lab-24.1.0.tgz",
+      "integrity": "sha512-/Y4wXRk8dmlTW0U8mFdnJAjNBAv/jEb0X/qXxY3nlVRnSI/BC2T6csipxEC+XNs41xgVYGbXh44ShpiYVY49NQ==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/bossy": "5.x.x",
+        "@hapi/eslint-plugin": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "babel-eslint": "10.x.x",
+        "diff": "4.x.x",
+        "eslint": "7.x.x",
+        "find-rc": "4.x.x",
+        "globby": "10.x.x",
+        "handlebars": "4.x.x",
+        "seedrandom": "3.x.x",
+        "source-map": "0.7.x",
+        "source-map-support": "0.5.x",
+        "supports-color": "7.x.x",
+        "will-call": "1.x.x"
+      },
+      "bin": {
+        "lab": "bin/lab"
+      }
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==",
+      "dev": true
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hapi/validate": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "node_modules/@hapi/wreck": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.1.0.tgz",
+      "integrity": "sha512-nx6sFyfqOpJ+EFrHX+XWwJAxs3ju4iHdbB/bwR8yTNZOiYmuhA8eCe7lYPtYmb4j7vyK/SlbaQsmTtUrMvPEBw==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.11.tgz",
+      "integrity": "sha512-BJ97wAUuU3NUiUCp44xzUFquQEvnk1wu7q4CMEUYKJWjdkr0YWYDsm4RFtAvxYsNjLsKcrFt6RvK8r+mnzMbEQ==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+      "dev": true
+    },
+    "node_modules/babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "dev": true,
+      "dependencies": {
+        "precond": "0.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/eraro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eraro/-/eraro-2.1.0.tgz",
+      "integrity": "sha512-i8t3tkUixYL6q9gQvTqgkOok8VJCw2mr3/YfATdFcOE2pxw3MUM8Uv4B822zVDPIyIZDKx7jixr24ej3vdul2A==",
+      "dev": true,
+      "dependencies": {
+        "lodash.template": "^4.5.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.15.0.tgz",
+      "integrity": "sha512-Vr64xFDT8w30wFll643e7cGrIkPEU50yIiI36OdSIDoSGguIeaLzBo0vpGvzo9RECUqq7htURfwEtKqwytkqzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.2.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^6.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
+      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-rc": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-4.0.1.tgz",
+      "integrity": "sha512-YEox27Ie95/zoqkxm6BYSPguJsvYz9d9G1YuaNKhxjSgZbjMC9q5blmvbL4+Ail8yacQIE0OObhDb+ZwvfJafw==",
+      "dev": true
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
+      "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "node_modules/gate-executor": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gate-executor/-/gate-executor-3.0.0.tgz",
+      "integrity": "sha512-FicIagg735qjvf2V/RqbFCl5zfOz/O0BX0b04LoRHr6DaViX2SJUeoTQW+Zx8uOC7Uec0GneA/qt0a/7FY4D1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/gex/-/gex-3.0.1.tgz",
+      "integrity": "sha512-fEc7EobSAmgQFK3TfKxqa4cRFmsJVAwhzz6wGsI6AVoApkgKy5RVhG2+QYBVccKZOo5I1ROhtlNUDCZNakDWpw==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "node_modules/jsonic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jsonic/-/jsonic-1.0.1.tgz",
+      "integrity": "sha512-6GitEN4plTuB/I1o9kDZl7Pgc+DvFG1BG88IqaUz4eQglCA1uAgxWdXhLNA6ffaYsmzPjOysDpp6CYTwRiuXLw==",
+      "dev": true
+    },
+    "node_modules/lab-transform-typescript": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lab-transform-typescript/-/lab-transform-typescript-3.0.1.tgz",
+      "integrity": "sha1-yaitzCu8eN/H8uM721S9N/FdQ5g=",
+      "dev": true,
+      "dependencies": {
+        "debug": "^2.6.0"
+      }
+    },
+    "node_modules/lab-transform-typescript/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lab-transform-typescript/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "node_modules/lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "node_modules/lodash.defaultsdeep": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
+      "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
+      "dev": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "node_modules/lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+      "dev": true
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "node_modules/lodash.isdate": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isdate/-/lodash.isdate-4.0.1.tgz",
+      "integrity": "sha1-NaVDZzuddhEN5BFLMsxXcEin82Y=",
+      "dev": true
+    },
+    "node_modules/lodash.isnan": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isnan/-/lodash.isnan-3.0.2.tgz",
+      "integrity": "sha1-gu0Epfnqi9YibQwmrwysMvRQd0U=",
+      "dev": true
+    },
+    "node_modules/lodash.isregexp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isregexp/-/lodash.isregexp-4.0.1.tgz",
+      "integrity": "sha1-4T5kezDNVZdSoEzZEghvr32hwws=",
+      "dev": true
+    },
+    "node_modules/lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "dev": true
+    },
+    "node_modules/lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "dev": true,
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "node_modules/lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "dev": true,
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      },
+      "bin": {
+        "ndjson": "cli.js"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/nid": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/nid/-/nid-1.3.3.tgz",
+      "integrity": "sha512-D4icLe9or1K4gsH8CQ2gfnRJECRlq63oNq5LNADMVmyPQqMhtHQIE3LE8bXDbQRYR8yzwoo0stG1m2pL5kr3aA==",
+      "dev": true
+    },
+    "node_modules/norma": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/norma/-/norma-2.0.2.tgz",
+      "integrity": "sha512-dpZEilsy4GuVX3E1/L/7xAFDsv5V7vopP/wOF/yxnw4Qy7vkEQZjL0lEv9nM7BMX0QZNOauL/oHAtZ10BUOTIA==",
+      "dev": true,
+      "dependencies": {
+        "eraro": "^2.0.0",
+        "lodash.isarguments": "^3.1.0",
+        "lodash.isdate": "^4.0.1",
+        "lodash.isnan": "^3.0.2",
+        "lodash.isregexp": "^4.0.1"
+      }
+    },
+    "node_modules/nua": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nua/-/nua-1.0.2.tgz",
+      "integrity": "sha512-M94zvCWqflfJ38ziwbIHKISUUdU3nOdrRY5L2LCan/inAbTJm2O+ajHNNajKaeDFLPVhi+6wx9nGv2ectGEIGg==",
+      "dev": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/optioner": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/optioner/-/optioner-5.0.1.tgz",
+      "integrity": "sha512-WrR6M1H5JnK9lI/0TUDtSdqTwTSLOno4EZR4dC/NAJIz1Z8HePbo37eJqlrx8KP4YpB6lhrtl621gRPuOhgoLQ==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.3",
+        "@hapi/joi": "^17.1.0"
+      }
+    },
+    "node_modules/ordu": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ordu/-/ordu-2.0.0.tgz",
+      "integrity": "sha512-NGTWwJsdAblziXhBrHkrPoukgpwt+o+NtEBRIZvMK9KWROWq3SBXhv+xu0jT9ersv4E6Z8Uk7L+WNlAf/7/5Jw==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.1.0",
+        "nua": "^1.0.2",
+        "strict-event-emitter-types": "^2.0.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/patrun": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/patrun/-/patrun-7.0.0.tgz",
+      "integrity": "sha512-HiaFz2q8Am5jD+fHn4nnfvNc3I1A06uZFFGFZaShUop20TndqALPSjf5pGPACzU/NpMd2U7uqS63kVLLEQN+FQ==",
+      "dev": true,
+      "dependencies": {
+        "gex": "^3.0.1"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/reconnect-core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/reconnect-core/-/reconnect-core-1.3.0.tgz",
+      "integrity": "sha1-+65SkZp4d9hE4yRtAaLyZwHIM8g=",
+      "dev": true,
+      "dependencies": {
+        "backoff": "~2.5.0"
+      }
+    },
+    "node_modules/regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rolling-stats": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/rolling-stats/-/rolling-stats-0.1.1.tgz",
+      "integrity": "sha1-zVr3dKiJOzCmdIMvovSrqkeM/IA=",
+      "dev": true
+    },
+    "node_modules/run-parallel": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
+      "dev": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seneca": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/seneca/-/seneca-3.23.0.tgz",
+      "integrity": "sha512-9/RXTzyAI+d3QnkNaA9tjSV42dHqv0Titp5Hys4A81V3UGil1Icsmr2DO6h0iymC2+IZt/Y2Y01hRtTh1K95zg==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/joi": "^17.1.1",
+        "@hapi/wreck": "^17.0.0",
+        "eraro": "^2.1.0",
+        "fast-safe-stringify": "^2.0.7",
+        "gate-executor": "^3.0.0",
+        "jsonic": "^1.0.1",
+        "lodash.defaultsdeep": "^4.6.1",
+        "lodash.flatten": "^4.4.0",
+        "lodash.uniq": "^4.5.0",
+        "minimist": "^1.2.5",
+        "nid": "^1.3.3",
+        "norma": "^2.0.2",
+        "optioner": "^5.0.1",
+        "ordu": "^2.0.0",
+        "patrun": "^7.0.0",
+        "qs": "^6.9.4",
+        "rolling-stats": "^0.1.1",
+        "seneca-transport": "^6.0.0",
+        "use-plugin": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seneca-entity": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/seneca-entity/-/seneca-entity-11.0.0.tgz",
+      "integrity": "sha512-tX6t5tKVsUCjln/lFvwdUFZvpHDhcKQCP+ZvwRf3MLYLKyyo0y9nD45VRK6I6/DFNWdsW6MB6SCLs//XgCh3fw==",
+      "dev": true,
+      "dependencies": {
+        "eraro": "^2.1.0",
+        "jsonic": "^1.0.1",
+        "nid": "^1.3.3",
+        "seneca-mem-store": "^4.0.1"
+      }
+    },
+    "node_modules/seneca-mem-store": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/seneca-mem-store/-/seneca-mem-store-4.0.1.tgz",
+      "integrity": "sha512-FnJRRNoG5uq2eULKriyrLyCk10xA3Te09UUPff8OfYq8AbjHRiw2BxWPw6GrFHNTq375DXph4pdQLj1+zVpcDg==",
+      "dev": true
+    },
+    "node_modules/seneca-promisify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/seneca-promisify/-/seneca-promisify-2.0.0.tgz",
+      "integrity": "sha512-xYpnZQAGJPrw1gytbpHc6rqvpbWPwA5Mt8Fl03d4mnn3zMN3to6Pgw29Nl1Ltz2bvnPsxusk2iETG/UnJtqgnQ==",
+      "dev": true,
+      "dependencies": {
+        "optioner": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seneca-store-test": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/seneca-store-test/-/seneca-store-test-3.1.0.tgz",
+      "integrity": "sha512-mxA5MzPbnlZxQ8aDRoec3d4M1NgrTLjQjikHbZkUT/KJk/N85BJu78jjl+0kveknN+P4uEXEMPMefUBvFWqxEQ==",
+      "dev": true,
+      "dependencies": {
+        "async": "^3.2.0",
+        "chai": "^4.2.0",
+        "nid": "^1.3.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/seneca-transport": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/seneca-transport/-/seneca-transport-6.0.0.tgz",
+      "integrity": "sha512-5x+Z9uwhpHysbmo+/Cifw0jmwowaEpn5KYPm7HLkHKBQDUdspPnI3084PbSLYfSPZADg8uy8XMvv093kbw1Kiw==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/wreck": "^17.0.0",
+        "eraro": "^2.1.0",
+        "gex": "^1.0.0",
+        "jsonic": "^0.3.1",
+        "lodash.foreach": "^4.5.0",
+        "lodash.omit": "^4.5.0",
+        "lru-cache": "^5.1.1",
+        "ndjson": "^1.5.0",
+        "nid": "^1.1.0",
+        "patrun": "^3.0.0",
+        "qs": "^6.9.4",
+        "reconnect-core": "^1.3.0"
+      }
+    },
+    "node_modules/seneca-transport/node_modules/gex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gex/-/gex-1.0.0.tgz",
+      "integrity": "sha512-wEyZcD4WWlL8IMw/ZOhWGfy4X/Q2yFqXZ16Loq/vh3XwsS+42Fm23Jd5ph+3yw9wNzVMmloskBwO3vCL8M7+2Q==",
+      "dev": true
+    },
+    "node_modules/seneca-transport/node_modules/jsonic": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/jsonic/-/jsonic-0.3.1.tgz",
+      "integrity": "sha512-5Md4EK3vPAMvP2sXY6M3/vQEPeX3LxEQBJuF979uypddXjsUlEoAI9/Nojh8tbw+YU5FjMoqSElO6oyjrAuprw==",
+      "dev": true
+    },
+    "node_modules/seneca-transport/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/seneca-transport/node_modules/patrun": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/patrun/-/patrun-3.0.0.tgz",
+      "integrity": "sha512-fQ++l3FCnrQbO03wEjb2SFn+ixGXscS8948A4js0qDTBsod0eElYUDvuWCH4mV61V/7QN2lCtryRvoyBP0K/7g==",
+      "dev": true,
+      "dependencies": {
+        "gex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/seneca-transport/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "dev": true,
+      "dependencies": {
+        "through2": "^2.0.2"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.1.tgz",
+      "integrity": "sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-plugin": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/use-plugin/-/use-plugin-8.2.0.tgz",
+      "integrity": "sha512-mISoqGU0ouiSn2QY3k8a88yPqgDilOMpVjXBswMVNibz1MmIzgtxNVRtFwsb30rNvfvl5ZGu44JQtP/gY4/1Bw==",
+      "dev": true,
+      "dependencies": {
+        "eraro": "^2.1.0",
+        "nid": "^1.1.0",
+        "norma": "^2.0.2",
+        "optioner": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "dev": true
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/will-call": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/will-call/-/will-call-1.0.1.tgz",
+      "integrity": "sha512-1hEeV8SfBYhNRc/bNXeQfyUBX8Dl9SCYME3qXh99iZP9wJcnhnlBsoBw8Y0lXVZ3YuPsoxImTzBiol1ouNR/hg==",
+      "dev": true
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.4",
@@ -1807,6 +4239,15 @@
       "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -1833,15 +4274,6 @@
             "ansi-regex": "^4.1.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -43,12 +43,13 @@
   "devDependencies": {
     "@hapi/code": "^8.0.2",
     "@hapi/lab": "^24.1.0",
+    "async": "3.2.0",
+    "lab-transform-typescript": "^3.0.1",
     "prettier": "^2.2.1",
     "seneca": "^3.23.0",
     "seneca-entity": "^11.0.0",
     "seneca-promisify": "^2.0.0",
     "seneca-store-test": "^3.1.0",
-    "lab-transform-typescript": "^3.0.1",
     "typescript": "^4.1.2"
   },
   "files": [

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -382,8 +382,6 @@ describe('mem-store tests', function () {
         })
       })
 
-      // TODO: WIP: Change this:
-      //
       describe('when some documents/records in the upsert$ directive match', () => {
         const app = makeSenecaForTest()
 
@@ -432,7 +430,7 @@ describe('mem-store tests', function () {
 
                   expect(products[1]).to.contain({
                     label: 'a toothbrush',
-                    price: '4.95'
+                    price: '3.70'
                   })
 
                   expect(products[2]).to.contain({

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -600,13 +600,7 @@ describe('mem-store tests', function () {
             .save$(fin)
         })
 
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'CS101 textbook', price: '134.95' })
-            .save$(fin)
-        })
-
-        it('updates the matching document', fin => {
+        it('can never match on undefined fields, hence a new document is created', fin => {
           app.test(fin)
 
           app.ready(() => {
@@ -630,12 +624,16 @@ describe('mem-store tests', function () {
                     //
                     // label: undefined,
 
-                    price: '5.95'
+                    price: '3.95'
                   })
 
                   expect(products[1]).to.contain({
-                    label: 'CS101 textbook',
-                    price: '134.95'
+                    // NOTE: WARNING: Seneca is stripping out fields
+                    // with a value of `undefined` in a document.
+                    //
+                    // label: undefined,
+
+                    price: '5.95'
                   })
 
                   return fin()

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -286,8 +286,8 @@ describe('mem-store tests', function () {
   })
 
   describe('upsert', () => {
-    describe('when creating a new document/record', () => {
-      describe('when a document/record in the upsert$ directive matches', () => {
+    describe('save$ invoked on a new entity instance', () => {
+      describe('matching entity exists', () => {
         const app = makeSenecaForTest()
 
         before(fin => app.ready(fin))
@@ -304,7 +304,7 @@ describe('mem-store tests', function () {
             .save$(fin)
         })
 
-        it('only updates a single matching document', fin => {
+        it('updates the entity', fin => {
           app.test(fin)
 
           app.ready(() => {
@@ -343,7 +343,7 @@ describe('mem-store tests', function () {
         })
       })
 
-      describe('when some documents/records in the upsert$ directive match', () => {
+      describe('many matching entities exist', () => {
         const app = makeSenecaForTest()
 
         before(fin => app.ready(fin))
@@ -366,7 +366,7 @@ describe('mem-store tests', function () {
             .save$(fin)
         })
 
-        it('only updates a single matching document', fin => {
+        it('updates a single matching entity', fin => {
           app.test(fin)
 
           app.ready(() => {
@@ -406,7 +406,7 @@ describe('mem-store tests', function () {
         })
       })
 
-      describe('when no documents/records in the upsert$ directive match', () => {
+      describe('no matching entities exist', () => {
         describe('normally', () => {
           const app = makeSenecaForTest()
 
@@ -418,7 +418,7 @@ describe('mem-store tests', function () {
               .save$(fin)
           })
 
-          it('creates a new document', fin => {
+          it('creates a new entity', fin => {
             app.test(fin)
 
             app.make('product')
@@ -451,12 +451,12 @@ describe('mem-store tests', function () {
           })
         })
 
-        describe('when bombarding the store with near-parallel upserts', () => {
+        describe('bombarding the store with near-parallel upserts', () => {
           const app = makeSenecaForTest()
 
           before(fin => app.ready(fin))
 
-          it('does not result in a race condition, and creates the resulting document only once', fin => {
+          it('does not result in a race condition - creates a single new entity', fin => {
             app.test(fin)
 
             const product_entity = app.entity('product')
@@ -497,363 +497,282 @@ describe('mem-store tests', function () {
         })
       })
 
-      describe('when a document/record in the upsert$ directive matches on a private field', () => {
-        const app = makeSenecaForTest()
-
-        before(fin => app.ready(fin))
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'toothbrush', price: '3.95', psst$: 'private' })
-            .save$(fin)
-        })
-
-        it('cannot match on private fields of a document', fin => {
-          app.test(fin)
-
-          app.ready(() => {
-            app.make('product')
-              .data$({ label: 'a new toothbrush', price: '5.95', psst$: 'private' })
-              .save$({ upsert$: ['psst$'] }, err => {
-                if (err) {
-                  return fin(err)
-                }
-
-                app.make('product').list$({}, (err, products) => {
-                  if (err) {
-                    return fin(err)
-                  }
-
-                  expect(products.length).to.equal(2)
-
-                  expect(products[0]).to.contain({
-                    label: 'toothbrush',
-                    price: '3.95'
-                  })
-
-                  expect(products[1]).to.contain({
-                    label: 'a new toothbrush',
-                    price: '5.95'
-                  })
-
-                  return fin()
-                })
-              })
-          })
-        })
-      })
-
-      describe('when the upsert$ directive is empty', () => {
-        const app = makeSenecaForTest()
-
-        before(fin => app.ready(fin))
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'toothbrush', price: '3.95' })
-            .save$(fin)
-        })
-
-        it('creates a new document', fin => {
-          app.test(fin)
-
-          app.ready(() => {
-            app.make('product')
-              .data$({ label: 'toothbrush', price: '5.95' })
-              .save$({ upsert$: [] }, err => {
-                if (err) {
-                  return fin(err)
-                }
-
-                app.make('product').list$({}, (err, products) => {
-                  if (err) {
-                    return fin(err)
-                  }
-
-                  expect(products.length).to.equal(2)
-
-                  expect(products[0]).to.contain({
-                    label: 'toothbrush',
-                    price: '3.95'
-                  })
-
-                  expect(products[1]).to.contain({
-                    label: 'toothbrush',
-                    price: '5.95'
-                  })
-
-                  return fin()
-                })
-              })
-          })
-        })
-      })
-
-      describe('when a document/record in the upsert$ directive matches on an existing field set to undefined', () => {
-        const app = makeSenecaForTest()
-
-        before(fin => app.ready(fin))
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: undefined, price: '3.95' })
-            .save$(fin)
-        })
-
-        it('can never match on undefined fields, hence a new document is created', fin => {
-          app.test(fin)
-
-          app.ready(() => {
-            app.make('product')
-              .data$({ label: undefined, price: '5.95' })
-              .save$({ upsert$: ['label'] }, err => {
-                if (err) {
-                  return fin(err)
-                }
-
-                app.make('product').list$({}, (err, products) => {
-                  if (err) {
-                    return fin(err)
-                  }
-
-                  expect(products.length).to.equal(2)
-
-                  expect(products[0]).to.contain({
-                    // NOTE: Seneca is stripping out fields
-                    // with a value of `undefined` in a document.
-                    //
-                    // label: undefined,
-
-                    price: '3.95'
-                  })
-
-                  expect(products[1]).to.contain({
-                    // NOTE: Seneca is stripping out fields
-                    // with a value of `undefined` in a document.
-                    //
-                    // label: undefined,
-
-                    price: '5.95'
-                  })
-
-                  return fin()
-                })
-              })
-          })
-        })
-      })
-
-      describe('when a document/record in the upsert$ directive matches on an existing field set to null', () => {
-        const app = makeSenecaForTest()
-
-        before(fin => app.ready(fin))
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: null, price: '3.95' })
-            .save$(fin)
-        })
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'CS101 textbook', price: '134.95' })
-            .save$(fin)
-        })
-
-        it('updates the matching document', fin => {
-          app.test(fin)
-
-          app.ready(() => {
-            app.make('product')
-              .data$({ label: null, price: '5.95' })
-              .save$({ upsert$: ['label'] }, err => {
-                if (err) {
-                  return fin(err)
-                }
-
-                app.make('product').list$({}, (err, products) => {
-                  if (err) {
-                    return fin(err)
-                  }
-
-                  expect(products.length).to.equal(2)
-
-                  expect(products[0]).to.contain({
-                    label: null,
-                    price: '5.95'
-                  })
-
-                  expect(products[1]).to.contain({
-                    label: 'CS101 textbook',
-                    price: '134.95'
-                  })
-
-                  return fin()
-                })
-              })
-          })
-        })
-      })
-
-      describe('when some of the fields in the data$/upsert$ directives do not exist in a document/record', () => {
-        const app = makeSenecaForTest()
-
-        before(fin => app.ready(fin))
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'a toothbrush', price: '3.40' })
-            .save$(fin)
-        })
-
-        it('creates a new document because it can never match any of the documents/records because the none of them have the queried-for fields', fin => {
-          app.test(fin)
-
-          app.make('product')
-            .data$({ label: 'a toothbrush', price: '2.95', coolness_factor: '0.95' })
-            .save$({ upsert$: ['label', 'coolness_factor'] }, err => {
-              if (err) {
-                return fin(err)
-              }
-
-              app.make('product').list$({}, (err, products) => {
-                if (err) {
-                  return fin(err)
-                }
-
-                expect(products.length).to.equal(2)
-
-                expect(products[1]).to.contain({
-                  label: 'a toothbrush',
-                  price: '2.95',
-                  coolness_factor: '0.95'
-                })
-
-
-                return fin()
-              })
-            })
-        })
-      })
-
-      describe('when some of the fields in the upsert$ directive do not exist in the attributes passed via data$', () => {
-        const app = makeSenecaForTest()
-
-        before(fin => app.ready(fin))
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'a toothbrush', price: '3.40' })
-            .save$(fin)
-        })
-
-        it('can never match, hence a new document is created', fin => {
-          app.test(fin)
-
-          app.make('product')
-            .data$({ label: 'a toothbrush', price: '2.95' })
-            .save$({ upsert$: ['label', 'coolness_factor'] }, err => {
-              if (err) {
-                return fin(err)
-              }
-
-              app.make('product').list$({}, (err, products) => {
-                if (err) {
-                  return fin(err)
-                }
-
-                expect(products.length).to.equal(2)
-
-                expect(products[0]).to.contain({
-                  label: 'a toothbrush',
-                  price: '3.40'
-                })
-
-                expect(products[1]).to.contain({
-                  label: 'a toothbrush',
-                  price: '2.95'
-                })
-
-                return fin()
-              })
-            })
-        })
-      })
-
-      describe('when upserting on an id', () => {
-        describe('when a document/record in the upsert$ directive matches', () => {
+      describe('edge cases', () => {
+        describe('entity matches on a private field', () => {
           const app = makeSenecaForTest()
 
           before(fin => app.ready(fin))
 
-
-          const id_of_richard = 'some_id'
-
           beforeEach(fin => {
-            app.make('user')
-              .data$({ id: id_of_richard, username: 'richard', points: 8000 })
+            app.make('product')
+              .data$({ label: 'toothbrush', price: '3.95', psst$: 'private' })
               .save$(fin)
           })
 
-
-          beforeEach(fin => {
-            app.make('user')
-              .data$({ username: 'bob', points: 1000 })
-              .save$(fin)
-          })
-
-          it('updates the matching document', fin => {
+          it('creates a new entity', fin => {
             app.test(fin)
 
-            app.make('user')
-              .data$({ id: id_of_richard, username: 'richard', points: 9999 })
-              .save$({ upsert$: ['id'] }, err => {
-                if (err) {
-                  return fin(err)
-                }
-
-                app.make('user').list$({}, (err, users) => {
+            app.ready(() => {
+              app.make('product')
+                .data$({ label: 'a new toothbrush', price: '5.95', psst$: 'private' })
+                .save$({ upsert$: ['psst$'] }, err => {
                   if (err) {
                     return fin(err)
                   }
 
-                  expect(users.length).to.equal(2)
+                  app.make('product').list$({}, (err, products) => {
+                    if (err) {
+                      return fin(err)
+                    }
 
-                  expect(users[0]).to.contain({
-                    id: id_of_richard,
-                    username: 'richard',
-                    points: 9999
+                    expect(products.length).to.equal(2)
+
+                    expect(products[0]).to.contain({
+                      label: 'toothbrush',
+                      price: '3.95'
+                    })
+
+                    expect(products[1]).to.contain({
+                      label: 'a new toothbrush',
+                      price: '5.95'
+                    })
+
+                    return fin()
+                  })
+                })
+            })
+          })
+        })
+
+        describe('empty upsert$ array', () => {
+          const app = makeSenecaForTest()
+
+          before(fin => app.ready(fin))
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'toothbrush', price: '3.95' })
+              .save$(fin)
+          })
+
+          it('creates a new document', fin => {
+            app.test(fin)
+
+            app.ready(() => {
+              app.make('product')
+                .data$({ label: 'toothbrush', price: '5.95' })
+                .save$({ upsert$: [] }, err => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  app.make('product').list$({}, (err, products) => {
+                    if (err) {
+                      return fin(err)
+                    }
+
+                    expect(products.length).to.equal(2)
+
+                    expect(products[0]).to.contain({
+                      label: 'toothbrush',
+                      price: '3.95'
+                    })
+
+                    expect(products[1]).to.contain({
+                      label: 'toothbrush',
+                      price: '5.95'
+                    })
+
+                    return fin()
+                  })
+                })
+            })
+          })
+        })
+
+        describe('entity matches on a field with the `undefined` value', () => {
+          const app = makeSenecaForTest()
+
+          before(fin => app.ready(fin))
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: undefined, price: '3.95' })
+              .save$(fin)
+          })
+
+          it('creates a new document', fin => {
+            app.test(fin)
+
+            app.ready(() => {
+              app.make('product')
+                .data$({ label: undefined, price: '5.95' })
+                .save$({ upsert$: ['label'] }, err => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  app.make('product').list$({}, (err, products) => {
+                    if (err) {
+                      return fin(err)
+                    }
+
+                    expect(products.length).to.equal(2)
+
+                    expect(products[0]).to.contain({
+                      // NOTE: Seneca is stripping out fields
+                      // with a value of `undefined` in a document.
+                      //
+                      // label: undefined,
+
+                      price: '3.95'
+                    })
+
+                    expect(products[1]).to.contain({
+                      // NOTE: Seneca is stripping out fields
+                      // with a value of `undefined` in a document.
+                      //
+                      // label: undefined,
+
+                      price: '5.95'
+                    })
+
+                    return fin()
+                  })
+                })
+            })
+          })
+        })
+
+        describe('entity matches on a field with the null value', () => {
+          const app = makeSenecaForTest()
+
+          before(fin => app.ready(fin))
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: null, price: '3.95' })
+              .save$(fin)
+          })
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'CS101 textbook', price: '134.95' })
+              .save$(fin)
+          })
+
+          it('updates the existing entity', fin => {
+            app.test(fin)
+
+            app.ready(() => {
+              app.make('product')
+                .data$({ label: null, price: '5.95' })
+                .save$({ upsert$: ['label'] }, err => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  app.make('product').list$({}, (err, products) => {
+                    if (err) {
+                      return fin(err)
+                    }
+
+                    expect(products.length).to.equal(2)
+
+                    expect(products[0]).to.contain({
+                      label: null,
+                      price: '5.95'
+                    })
+
+                    expect(products[1]).to.contain({
+                      label: 'CS101 textbook',
+                      price: '134.95'
+                    })
+
+                    return fin()
+                  })
+                })
+            })
+          })
+        })
+
+        describe('some fields in data$/upsert$ are not present in existing entities', () => {
+          const app = makeSenecaForTest()
+
+          before(fin => app.ready(fin))
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'a toothbrush', price: '3.40' })
+              .save$(fin)
+          })
+
+          it('creates a new entity', fin => {
+            app.test(fin)
+
+            app.make('product')
+              .data$({ label: 'a toothbrush', price: '2.95', coolness_factor: '0.95' })
+              .save$({ upsert$: ['label', 'coolness_factor'] }, err => {
+                if (err) {
+                  return fin(err)
+                }
+
+                app.make('product').list$({}, (err, products) => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  expect(products.length).to.equal(2)
+
+                  expect(products[1]).to.contain({
+                    label: 'a toothbrush',
+                    price: '2.95',
+                    coolness_factor: '0.95'
                   })
 
-                  expect(users[1]).to.contain({
-                    username: 'bob',
-                    points: 1000
-                  })
 
                   return fin()
                 })
               })
           })
+        })
 
-          it('can still retrieve the updated document by the given id via the #load$ method', fin => {
+        describe('fields in upsert$ are not present in the data$ object', () => {
+          const app = makeSenecaForTest()
+
+          before(fin => app.ready(fin))
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'a toothbrush', price: '3.40' })
+              .save$(fin)
+          })
+
+          it('creates a new entity because it can never match', fin => {
             app.test(fin)
 
-            app.make('user')
-              .data$({ id: id_of_richard, username: 'richard', points: 9999 })
-              .save$({ upsert$: ['id'] }, err => {
+            app.make('product')
+              .data$({ label: 'a toothbrush', price: '2.95' })
+              .save$({ upsert$: ['label', 'coolness_factor'] }, err => {
                 if (err) {
                   return fin(err)
                 }
 
-                app.make('user').load$(id_of_richard, (err, user) => {
+                app.make('product').list$({}, (err, products) => {
                   if (err) {
                     return fin(err)
                   }
 
-                  expect(user).to.contain({
-                    id: id_of_richard,
-                    username: 'richard',
-                    points: 9999
+                  expect(products.length).to.equal(2)
+
+                  expect(products[0]).to.contain({
+                    label: 'a toothbrush',
+                    price: '3.40'
+                  })
+
+                  expect(products[1]).to.contain({
+                    label: 'a toothbrush',
+                    price: '2.95'
                   })
 
                   return fin()
@@ -862,80 +781,163 @@ describe('mem-store tests', function () {
           })
         })
 
-        describe('when no documents/records in the upsert$ directive match', () => {
-          const app = makeSenecaForTest()
+        describe('upserting on the id field', () => {
+          describe('matching entity exists', () => {
+            const app = makeSenecaForTest()
 
-          before(fin => app.ready(fin))
+            before(fin => app.ready(fin))
 
-          const some_id = 'some_id'
 
-          beforeEach(fin => {
-            app.make('user')
-              .data$({ username: 'richard' })
-              .save$(fin)
-          })
+            const id_of_richard = 'some_id'
 
-          it('creates a new document with that id', fin => {
-            app.test(fin)
+            beforeEach(fin => {
+              app.make('user')
+                .data$({ id: id_of_richard, username: 'richard', points: 8000 })
+                .save$(fin)
+            })
 
-            app.make('user')
-              .data$({ id: some_id, username: 'jim' })
-              .save$({ upsert$: ['id'] }, err => {
-                if (err) {
-                  return fin(err)
-                }
 
-                app.make('user').list$({}, (err, users) => {
+            beforeEach(fin => {
+              app.make('user')
+                .data$({ username: 'bob', points: 1000 })
+                .save$(fin)
+            })
+
+            it('updates the matching entity', fin => {
+              app.test(fin)
+
+              app.make('user')
+                .data$({ id: id_of_richard, username: 'richard', points: 9999 })
+                .save$({ upsert$: ['id'] }, err => {
                   if (err) {
                     return fin(err)
                   }
 
-                  expect(users.length).to.equal(2)
+                  app.make('user').list$({}, (err, users) => {
+                    if (err) {
+                      return fin(err)
+                    }
 
-                  expect(users[0]).to.contain({
-                    username: 'richard'
+                    expect(users.length).to.equal(2)
+
+                    expect(users[0]).to.contain({
+                      id: id_of_richard,
+                      username: 'richard',
+                      points: 9999
+                    })
+
+                    expect(users[1]).to.contain({
+                      username: 'bob',
+                      points: 1000
+                    })
+
+                    return fin()
                   })
-
-                  expect(users[1]).to.contain({
-                    id: some_id,
-                    username: 'jim'
-                  })
-
-                  return fin()
                 })
-              })
-          })
+            })
 
-          it('can retrieve the new document by the given id via the #load$ method', fin => {
-            app.test(fin)
+            it('works with load$ after the update', fin => {
+              app.test(fin)
 
-            app.make('user')
-              .data$({ id: some_id, username: 'jim' })
-              .save$({ upsert$: ['id'] }, err => {
-                if (err) {
-                  return fin(err)
-                }
-
-                app.make('user').load$(some_id, (err, user) => {
+              app.make('user')
+                .data$({ id: id_of_richard, username: 'richard', points: 9999 })
+                .save$({ upsert$: ['id'] }, err => {
                   if (err) {
                     return fin(err)
                   }
 
-                  expect(user).to.contain({
-                    id: some_id,
-                    username: 'jim'
-                  })
+                  app.make('user').load$(id_of_richard, (err, user) => {
+                    if (err) {
+                      return fin(err)
+                    }
 
-                  return fin()
+                    expect(user).to.contain({
+                      id: id_of_richard,
+                      username: 'richard',
+                      points: 9999
+                    })
+
+                    return fin()
+                  })
                 })
-              })
+            })
+          })
+
+          describe('matching entity does not exist', () => {
+            const app = makeSenecaForTest()
+
+            before(fin => app.ready(fin))
+
+            const some_id = 'some_id'
+
+            beforeEach(fin => {
+              app.make('user')
+                .data$({ username: 'richard' })
+                .save$(fin)
+            })
+
+            it('creates a new document with that id', fin => {
+              app.test(fin)
+
+              app.make('user')
+                .data$({ id: some_id, username: 'jim' })
+                .save$({ upsert$: ['id'] }, err => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  app.make('user').list$({}, (err, users) => {
+                    if (err) {
+                      return fin(err)
+                    }
+
+                    expect(users.length).to.equal(2)
+
+                    expect(users[0]).to.contain({
+                      username: 'richard'
+                    })
+
+                    expect(users[1]).to.contain({
+                      id: some_id,
+                      username: 'jim'
+                    })
+
+                    return fin()
+                  })
+                })
+            })
+
+            it('works with load$ after the creation', fin => {
+              app.test(fin)
+
+              app.make('user')
+                .data$({ id: some_id, username: 'jim' })
+                .save$({ upsert$: ['id'] }, err => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  app.make('user').load$(some_id, (err, user) => {
+                    if (err) {
+                      return fin(err)
+                    }
+
+                    expect(user).to.contain({
+                      id: some_id,
+                      username: 'jim'
+                    })
+
+                    return fin()
+                  })
+                })
+            })
           })
         })
       })
     })
 
-    describe('when invoking upsert via the #save method of an existing entity', () => {
-      describe('when an existing document/record in the upsert$ directive matches', () => {
+    describe('save$ invoked as a method on an existing entity instance', () => {
+      describe('a matching entity exists', () => {
         const app = makeSenecaForTest()
 
         before(fin => app.ready(fin))
@@ -957,7 +959,15 @@ describe('mem-store tests', function () {
             })
         })
 
-        it('ignores the upsert$ directive and updates the entity the update is called on, as it normally would', fin => {
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'a macchiato espressionado', price: '7.99' })
+            .save$(fin)
+        })
+
+
+        it('ignores the upsert$ directive and updates the existing entity, as it normally would', fin => {
           app.test(fin)
 
           existing_product
@@ -972,11 +982,16 @@ describe('mem-store tests', function () {
                   return fin(err)
                 }
 
-                expect(products.length).to.equal(1)
+                expect(products.length).to.equal(2)
 
                 expect(products[0]).to.contain({
                   label: 'a macchiato espressionado',
                   price: '3.95'
+                })
+
+                expect(products[1]).to.contain({
+                  label: 'a macchiato espressionado',
+                  price: '7.99'
                 })
 
                 return fin()

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -577,8 +577,8 @@ describe('mem-store tests', function () {
                   expect(products.length).to.equal(2)
 
                   expect(products[0]).to.contain({
-                    // NOTE: WARNING: Seneca seems to be stripping out fields
-                    // with a value of undefined in a document.
+                    // NOTE: WARNING: Seneca is stripping out fields
+                    // with a value of `undefined` in a document.
                     //
                     // label: undefined,
 

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -619,7 +619,7 @@ describe('mem-store tests', function () {
                   expect(products.length).to.equal(2)
 
                   expect(products[0]).to.contain({
-                    // NOTE: WARNING: Seneca is stripping out fields
+                    // NOTE: Seneca is stripping out fields
                     // with a value of `undefined` in a document.
                     //
                     // label: undefined,
@@ -628,7 +628,7 @@ describe('mem-store tests', function () {
                   })
 
                   expect(products[1]).to.contain({
-                    // NOTE: WARNING: Seneca is stripping out fields
+                    // NOTE: Seneca is stripping out fields
                     // with a value of `undefined` in a document.
                     //
                     // label: undefined,

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -285,125 +285,22 @@ describe('mem-store tests', function () {
   })
 
   describe('upsert', () => {
-    describe('when no documents/records in the upsert$ directive match', () => {
-      const app = makeSenecaForTest()
+    describe('when creating a new document/record', () => {
+      describe('when no documents/records in the upsert$ directive match', () => {
+        const app = makeSenecaForTest()
 
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'a macchiato espressionado', price: '3.40' })
-          .save$(fin)
-      })
-
-      it('creates a new document', fin => {
-        app.test(fin)
-
-        app.make('product')
-          .data$({ label: 'b toothbrush', price: '3.40' })
-          .save$({ upsert$: ['label'] }, err => {
-            if (err) {
-              return fin(err)
-            }
-
-            app.make('product').list$({}, (err, products) => {
-              if (err) {
-                return fin(err)
-              }
-
-              expect(products.length).to.equal(2)
-
-              expect(products[0]).to.contain({
-                label: 'a macchiato espressionado',
-                price: '3.40'
-              })
-
-              expect(products[1]).to.contain({
-                label: 'b toothbrush',
-                price: '3.40'
-              })
-
-              return fin()
-            })
-          })
-      })
-    })
-
-    describe('when some documents/records in the upsert$ directive match', () => {
-      const app = makeSenecaForTest()
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'a toothbrush', price: '3.95' })
-          .save$(fin)
-      })
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'a toothbrush', price: '3.70' })
-          .save$(fin)
-      })
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'bbs tires', price: '4.10' })
-          .save$(fin)
-      })
-
-      it('updates the matching documents', fin => {
-        app.test(fin)
-
-        app.ready(() => {
+        beforeEach(fin => {
           app.make('product')
-            .data$({ label: 'a toothbrush', price: '4.95' })
-            .save$({ upsert$: ['label'] }, err => {
-              if (err) {
-                return fin(err)
-              }
-
-              app.make('product').list$({}, (err, products) => {
-                if (err) {
-                  return fin(err)
-                }
-
-                expect(products.length).to.equal(3)
-
-                expect(products[0]).to.contain({
-                  label: 'a toothbrush',
-                  price: '4.95'
-                })
-
-                expect(products[1]).to.contain({
-                  label: 'a toothbrush',
-                  price: '4.95'
-                })
-
-                expect(products[2]).to.contain({
-                  label: 'bbs tires',
-                  price: '4.10'
-                })
-
-                return fin()
-              })
-            })
+            .data$({ label: 'a macchiato espressionado', price: '3.40' })
+            .save$(fin)
         })
-      })
-    })
 
-    describe('when a document/record in the upsert$ directive matches on a private field', () => {
-      const app = makeSenecaForTest()
+        it('creates a new document', fin => {
+          app.test(fin)
 
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'toothbrush', price: '3.95', psst$: 'private' })
-          .save$(fin)
-      })
-
-      it('cannot match on private fields of a document', fin => {
-        app.test(fin)
-
-        app.ready(() => {
           app.make('product')
-            .data$({ label: 'a new toothbrush', price: '5.95', psst$: 'private' })
-            .save$({ upsert$: ['psst$'] }, err => {
+            .data$({ label: 'b toothbrush', price: '3.40' })
+            .save$({ upsert$: ['label'] }, err => {
               if (err) {
                 return fin(err)
               }
@@ -416,243 +313,409 @@ describe('mem-store tests', function () {
                 expect(products.length).to.equal(2)
 
                 expect(products[0]).to.contain({
-                  label: 'toothbrush',
+                  label: 'a macchiato espressionado',
+                  price: '3.40'
+                })
+
+                expect(products[1]).to.contain({
+                  label: 'b toothbrush',
+                  price: '3.40'
+                })
+
+                return fin()
+              })
+            })
+        })
+      })
+
+      describe('when some documents/records in the upsert$ directive match', () => {
+        const app = makeSenecaForTest()
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'a toothbrush', price: '3.95' })
+            .save$(fin)
+        })
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'a toothbrush', price: '3.70' })
+            .save$(fin)
+        })
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'bbs tires', price: '4.10' })
+            .save$(fin)
+        })
+
+        it('updates the matching documents', fin => {
+          app.test(fin)
+
+          app.ready(() => {
+            app.make('product')
+              .data$({ label: 'a toothbrush', price: '4.95' })
+              .save$({ upsert$: ['label'] }, err => {
+                if (err) {
+                  return fin(err)
+                }
+
+                app.make('product').list$({}, (err, products) => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  expect(products.length).to.equal(3)
+
+                  expect(products[0]).to.contain({
+                    label: 'a toothbrush',
+                    price: '4.95'
+                  })
+
+                  expect(products[1]).to.contain({
+                    label: 'a toothbrush',
+                    price: '4.95'
+                  })
+
+                  expect(products[2]).to.contain({
+                    label: 'bbs tires',
+                    price: '4.10'
+                  })
+
+                  return fin()
+                })
+              })
+          })
+        })
+      })
+
+      describe('when a document/record in the upsert$ directive matches on a private field', () => {
+        const app = makeSenecaForTest()
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'toothbrush', price: '3.95', psst$: 'private' })
+            .save$(fin)
+        })
+
+        it('cannot match on private fields of a document', fin => {
+          app.test(fin)
+
+          app.ready(() => {
+            app.make('product')
+              .data$({ label: 'a new toothbrush', price: '5.95', psst$: 'private' })
+              .save$({ upsert$: ['psst$'] }, err => {
+                if (err) {
+                  return fin(err)
+                }
+
+                app.make('product').list$({}, (err, products) => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  expect(products.length).to.equal(2)
+
+                  expect(products[0]).to.contain({
+                    label: 'toothbrush',
+                    price: '3.95'
+                  })
+
+                  expect(products[1]).to.contain({
+                    label: 'a new toothbrush',
+                    price: '5.95'
+                  })
+
+                  return fin()
+                })
+              })
+          })
+        })
+      })
+
+      describe('when the upsert$ directive is empty', () => {
+        const app = makeSenecaForTest()
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'toothbrush', price: '3.95' })
+            .save$(fin)
+        })
+
+        it('creates a new document', fin => {
+          app.test(fin)
+
+          app.ready(() => {
+            app.make('product')
+              .data$({ label: 'toothbrush', price: '5.95' })
+              .save$({ upsert$: [] }, err => {
+                if (err) {
+                  return fin(err)
+                }
+
+                app.make('product').list$({}, (err, products) => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  expect(products.length).to.equal(2)
+
+                  expect(products[0]).to.contain({
+                    label: 'toothbrush',
+                    price: '3.95'
+                  })
+
+                  expect(products[1]).to.contain({
+                    label: 'toothbrush',
+                    price: '5.95'
+                  })
+
+                  return fin()
+                })
+              })
+          })
+        })
+      })
+
+      describe('when a document/record in the upsert$ directive matches on an existing field set to undefined', () => {
+        const app = makeSenecaForTest()
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: undefined, price: '3.95' })
+            .save$(fin)
+        })
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'CS101 textbook', price: '134.95' })
+            .save$(fin)
+        })
+
+        it('updates the matching document', fin => {
+          app.test(fin)
+
+          app.ready(() => {
+            app.make('product')
+              .data$({ label: undefined, price: '5.95' })
+              .save$({ upsert$: ['label'] }, err => {
+                if (err) {
+                  return fin(err)
+                }
+
+                app.make('product').list$({}, (err, products) => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  expect(products.length).to.equal(2)
+
+                  expect(products[0]).to.contain({
+                    // NOTE: WARNING: Seneca seems to be stripping out fields
+                    // with a value of undefined in a document.
+                    //
+                    // label: undefined,
+
+                    price: '5.95'
+                  })
+
+                  expect(products[1]).to.contain({
+                    label: 'CS101 textbook',
+                    price: '134.95'
+                  })
+
+                  return fin()
+                })
+              })
+          })
+        })
+      })
+
+      describe('when a document/record in the upsert$ directive matches on an existing field set to null', () => {
+        const app = makeSenecaForTest()
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: null, price: '3.95' })
+            .save$(fin)
+        })
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'CS101 textbook', price: '134.95' })
+            .save$(fin)
+        })
+
+        it('updates the matching document', fin => {
+          app.test(fin)
+
+          app.ready(() => {
+            app.make('product')
+              .data$({ label: null, price: '5.95' })
+              .save$({ upsert$: ['label'] }, err => {
+                if (err) {
+                  return fin(err)
+                }
+
+                app.make('product').list$({}, (err, products) => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  expect(products.length).to.equal(2)
+
+                  expect(products[0]).to.contain({
+                    label: null,
+                    price: '5.95'
+                  })
+
+                  expect(products[1]).to.contain({
+                    label: 'CS101 textbook',
+                    price: '134.95'
+                  })
+
+                  return fin()
+                })
+              })
+          })
+        })
+      })
+
+      describe('when some of the fields in the data$/upsert$ directives do not exist in a document/record', () => {
+        const app = makeSenecaForTest()
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'a toothbrush', price: '3.40' })
+            .save$(fin)
+        })
+
+        it('creates a new document because it can never match any of the documents/records because the none of them have the queried-for fields', fin => {
+          app.test(fin)
+
+          app.make('product')
+            .data$({ label: 'a toothbrush', price: '2.95', coolness_factor: '0.95' })
+            .save$({ upsert$: ['label', 'coolness_factor'] }, err => {
+              if (err) {
+                return fin(err)
+              }
+
+              app.make('product').list$({}, (err, products) => {
+                if (err) {
+                  return fin(err)
+                }
+
+                expect(products.length).to.equal(2)
+
+                expect(products[1]).to.contain({
+                  label: 'a toothbrush',
+                  price: '2.95',
+                  coolness_factor: '0.95'
+                })
+
+
+                return fin()
+              })
+            })
+        })
+      })
+
+      describe('when some of the fields in the upsert$ directive do not exist in the attributes passed via data$', () => {
+        const app = makeSenecaForTest()
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'a toothbrush', price: '3.40' })
+            .save$(fin)
+        })
+
+        it('ignores the missing fields and updates the matching existing record', fin => {
+          app.test(fin)
+
+          app.make('product')
+            .data$({ label: 'a toothbrush', price: '2.95' })
+            .save$({ upsert$: ['label', 'coolness_factor'] }, err => {
+              if (err) {
+                return fin(err)
+              }
+
+              app.make('product').list$({}, (err, products) => {
+                if (err) {
+                  return fin(err)
+                }
+
+                expect(products.length).to.equal(1)
+
+                expect(products[0]).to.contain({
+                  label: 'a toothbrush',
+                  price: '2.95'
+                })
+
+                return fin()
+              })
+            })
+        })
+      })
+    })
+
+    describe('when invoking upsert via the #save method of an existing entity', () => {
+      describe('when some other existing documents/records in the upsert$ directive match', () => {
+        const app = makeSenecaForTest()
+
+
+        let existing_product
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'a macchiato espressionado', price: '3.40' })
+            .save$((err, new_product) => {
+              if (err) {
+                return fin(err)
+              }
+
+              existing_product = new_product
+
+              return fin()
+            })
+        })
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'a macchiato espressionado', price: '1.95' })
+            .save$(fin)
+        })
+
+        it('ignores the upsert$ directive and updates the entity the update is called on, as it normally would', fin => {
+          app.test(fin)
+
+          existing_product
+            .data$({ label: 'a macchiato espressionado', price: '3.95' })
+            .save$({ upsert$: ['label'] }, err => {
+              if (err) {
+                return fin(err)
+              }
+
+              app.make('product').list$({}, (err, products) => {
+                if (err) {
+                  return fin(err)
+                }
+
+                expect(products.length).to.equal(2)
+
+                expect(products[0]).to.contain({
+                  label: 'a macchiato espressionado',
                   price: '3.95'
                 })
 
                 expect(products[1]).to.contain({
-                  label: 'a new toothbrush',
-                  price: '5.95'
+                  label: 'a macchiato espressionado',
+                  price: '1.95'
                 })
 
                 return fin()
               })
             })
         })
-      })
-    })
-
-    describe('when the upsert$ directive is empty', () => {
-      const app = makeSenecaForTest()
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'toothbrush', price: '3.95' })
-          .save$(fin)
-      })
-
-      it('creates a new document', fin => {
-        app.test(fin)
-
-        app.ready(() => {
-          app.make('product')
-            .data$({ label: 'toothbrush', price: '5.95' })
-            .save$({ upsert$: [] }, err => {
-              if (err) {
-                return fin(err)
-              }
-
-              app.make('product').list$({}, (err, products) => {
-                if (err) {
-                  return fin(err)
-                }
-
-                expect(products.length).to.equal(2)
-
-                expect(products[0]).to.contain({
-                  label: 'toothbrush',
-                  price: '3.95'
-                })
-
-                expect(products[1]).to.contain({
-                  label: 'toothbrush',
-                  price: '5.95'
-                })
-
-                return fin()
-              })
-            })
-        })
-      })
-    })
-
-    describe('when a document/record in the upsert$ directive matches on an existing field set to undefined', () => {
-      const app = makeSenecaForTest()
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: undefined, price: '3.95' })
-          .save$(fin)
-      })
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'CS101 textbook', price: '134.95' })
-          .save$(fin)
-      })
-
-      it('updates the matching document', fin => {
-        app.test(fin)
-
-        app.ready(() => {
-          app.make('product')
-            .data$({ label: undefined, price: '5.95' })
-            .save$({ upsert$: ['label'] }, err => {
-              if (err) {
-                return fin(err)
-              }
-
-              app.make('product').list$({}, (err, products) => {
-                if (err) {
-                  return fin(err)
-                }
-
-                expect(products.length).to.equal(2)
-
-                expect(products[0]).to.contain({
-                  // NOTE: WARNING: Seneca seems to be stripping out fields
-                  // with a value of undefined in a document.
-                  //
-                  // label: undefined,
-
-                  price: '5.95'
-                })
-
-                expect(products[1]).to.contain({
-                  label: 'CS101 textbook',
-                  price: '134.95'
-                })
-
-                return fin()
-              })
-            })
-        })
-      })
-    })
-
-    describe('when a document/record in the upsert$ directive matches on an existing field set to null', () => {
-      const app = makeSenecaForTest()
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: null, price: '3.95' })
-          .save$(fin)
-      })
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'CS101 textbook', price: '134.95' })
-          .save$(fin)
-      })
-
-      it('updates the matching document', fin => {
-        app.test(fin)
-
-        app.ready(() => {
-          app.make('product')
-            .data$({ label: null, price: '5.95' })
-            .save$({ upsert$: ['label'] }, err => {
-              if (err) {
-                return fin(err)
-              }
-
-              app.make('product').list$({}, (err, products) => {
-                if (err) {
-                  return fin(err)
-                }
-
-                expect(products.length).to.equal(2)
-
-                expect(products[0]).to.contain({
-                  label: null,
-                  price: '5.95'
-                })
-
-                expect(products[1]).to.contain({
-                  label: 'CS101 textbook',
-                  price: '134.95'
-                })
-
-                return fin()
-              })
-            })
-        })
-      })
-    })
-
-    describe('when some of the fields in the data$/upsert$ directives do not exist in a document/record', () => {
-      const app = makeSenecaForTest()
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'a toothbrush', price: '3.40' })
-          .save$(fin)
-      })
-
-      it('creates a new document because it can never match any of the documents/records because the none of them have the queried-for fields', fin => {
-        app.test(fin)
-
-        app.make('product')
-          .data$({ label: 'a toothbrush', price: '2.95', coolness_factor: '0.95' })
-          .save$({ upsert$: ['label', 'coolness_factor'] }, err => {
-            if (err) {
-              return fin(err)
-            }
-
-            app.make('product').list$({}, (err, products) => {
-              if (err) {
-                return fin(err)
-              }
-
-              expect(products.length).to.equal(2)
-
-              expect(products[1]).to.contain({
-                label: 'a toothbrush',
-                price: '2.95',
-                coolness_factor: '0.95'
-              })
-
-
-              return fin()
-            })
-          })
-      })
-    })
-
-    describe('when some of the fields in the upsert$ directive do not exist in the attributes passed via data$', () => {
-      const app = makeSenecaForTest()
-
-      beforeEach(fin => {
-        app.make('product')
-          .data$({ label: 'a toothbrush', price: '3.40' })
-          .save$(fin)
-      })
-
-      it('ignores the missing fields and updates the matching existing record', fin => {
-        app.test(fin)
-
-        app.make('product')
-          .data$({ label: 'a toothbrush', price: '2.95' })
-          .save$({ upsert$: ['label', 'coolness_factor'] }, err => {
-            if (err) {
-              return fin(err)
-            }
-
-            app.make('product').list$({}, (err, products) => {
-              if (err) {
-                return fin(err)
-              }
-
-              expect(products.length).to.equal(1)
-
-              expect(products[0]).to.contain({
-                label: 'a toothbrush',
-                price: '2.95'
-              })
-
-              return fin()
-            })
-          })
       })
     })
   })

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -749,7 +749,7 @@ describe('mem-store tests', function () {
             .save$(fin)
         })
 
-        it('ignores the missing fields and updates the matching existing record', fin => {
+        it('can never match, hence a new document is created', fin => {
           app.test(fin)
 
           app.make('product')
@@ -764,9 +764,14 @@ describe('mem-store tests', function () {
                   return fin(err)
                 }
 
-                expect(products.length).to.equal(1)
+                expect(products.length).to.equal(2)
 
                 expect(products[0]).to.contain({
+                  label: 'a toothbrush',
+                  price: '3.40'
+                })
+
+                expect(products[1]).to.contain({
                   label: 'a toothbrush',
                   price: '2.95'
                 })

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -407,11 +407,11 @@ describe('mem-store tests', function () {
       })
 
       describe('when no documents/records in the upsert$ directive match', () => {
-        const app = makeSenecaForTest()
-
-        before(fin => app.ready(fin))
-
         describe('normally', () => {
+          const app = makeSenecaForTest()
+
+          before(fin => app.ready(fin))
+
           beforeEach(fin => {
             app.make('product')
               .data$({ label: 'a macchiato espressionado', price: '3.40' })
@@ -452,6 +452,10 @@ describe('mem-store tests', function () {
         })
 
         describe('when bombarding the store with near-parallel upserts', () => {
+          const app = makeSenecaForTest()
+
+          before(fin => app.ready(fin))
+
           it('does not result in a race condition, and creates the resulting document only once', fin => {
             app.test(fin)
 

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -286,64 +286,20 @@ describe('mem-store tests', function () {
 
   describe('upsert', () => {
     describe('when creating a new document/record', () => {
-      describe('when no documents/records in the upsert$ directive match', () => {
-        const app = makeSenecaForTest()
-
-        before(fin => app.ready(fin))
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'a macchiato espressionado', price: '3.40' })
-            .save$(fin)
-        })
-
-        it('creates a new document', fin => {
-          app.test(fin)
-
-          app.make('product')
-            .data$({ label: 'b toothbrush', price: '3.40' })
-            .save$({ upsert$: ['label'] }, err => {
-              if (err) {
-                return fin(err)
-              }
-
-              app.make('product').list$({}, (err, products) => {
-                if (err) {
-                  return fin(err)
-                }
-
-                expect(products.length).to.equal(2)
-
-                expect(products[0]).to.contain({
-                  label: 'a macchiato espressionado',
-                  price: '3.40'
-                })
-
-                expect(products[1]).to.contain({
-                  label: 'b toothbrush',
-                  price: '3.40'
-                })
-
-                return fin()
-              })
-            })
-        })
-      })
-
       describe('when a document/record in the upsert$ directive matches', () => {
         const app = makeSenecaForTest()
 
         before(fin => app.ready(fin))
 
         beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'a toothbrush', price: '3.95' })
+          app.make('user')
+            .data$({ username: 'richard' })
             .save$(fin)
         })
 
         beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'bbs tires', price: '4.10' })
+          app.make('user')
+            .data$({ username: 'bob' })
             .save$(fin)
         })
 
@@ -351,29 +307,33 @@ describe('mem-store tests', function () {
           app.test(fin)
 
           app.ready(() => {
-            app.make('product')
-              .data$({ label: 'a toothbrush', price: '4.95' })
-              .save$({ upsert$: ['label'] }, err => {
+            app.make('user')
+              .data$({ username: 'richard', points: 9999 })
+              .save$({ upsert$: ['username'] }, err => {
                 if (err) {
                   return fin(err)
                 }
 
-                app.make('product').list$({}, (err, products) => {
+                app.make('user').list$({}, (err, users) => {
                   if (err) {
                     return fin(err)
                   }
 
-                  expect(products.length).to.equal(2)
+                  expect(users.length).to.equal(2)
 
-                  expect(products[0]).to.contain({
-                    label: 'a toothbrush',
-                    price: '4.95'
+
+                  expect(users[0]).to.contain({
+                    username: 'richard',
+                    points: 9999
                   })
 
-                  expect(products[1]).to.contain({
-                    label: 'bbs tires',
-                    price: '4.10'
+
+                  expect(users[1]).to.contain({
+                    username: 'bob'
                   })
+
+                  expect(users[1]).to.not.contain('points')
+
 
                   return fin()
                 })
@@ -442,6 +402,50 @@ describe('mem-store tests', function () {
                 })
               })
           })
+        })
+      })
+
+      describe('when no documents/records in the upsert$ directive match', () => {
+        const app = makeSenecaForTest()
+
+        before(fin => app.ready(fin))
+
+        beforeEach(fin => {
+          app.make('product')
+            .data$({ label: 'a macchiato espressionado', price: '3.40' })
+            .save$(fin)
+        })
+
+        it('creates a new document', fin => {
+          app.test(fin)
+
+          app.make('product')
+            .data$({ label: 'b toothbrush', price: '3.40' })
+            .save$({ upsert$: ['label'] }, err => {
+              if (err) {
+                return fin(err)
+              }
+
+              app.make('product').list$({}, (err, products) => {
+                if (err) {
+                  return fin(err)
+                }
+
+                expect(products.length).to.equal(2)
+
+                expect(products[0]).to.contain({
+                  label: 'a macchiato espressionado',
+                  price: '3.40'
+                })
+
+                expect(products[1]).to.contain({
+                  label: 'b toothbrush',
+                  price: '3.40'
+                })
+
+                return fin()
+              })
+            })
         })
       })
 

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -15,7 +15,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const { expect } = Code
 const lab = (exports.lab = Lab.script())
-const { describe, beforeEach } = lab
+const { describe, before, beforeEach } = lab
 const it = make_it(lab)
 // const before = lab.before
 
@@ -289,6 +289,8 @@ describe('mem-store tests', function () {
       describe('when no documents/records in the upsert$ directive match', () => {
         const app = makeSenecaForTest()
 
+        before(fin => app.ready(fin))
+
         beforeEach(fin => {
           app.make('product')
             .data$({ label: 'a macchiato espressionado', price: '3.40' })
@@ -330,6 +332,8 @@ describe('mem-store tests', function () {
 
       describe('when some documents/records in the upsert$ directive match', () => {
         const app = makeSenecaForTest()
+
+        before(fin => app.ready(fin))
 
         beforeEach(fin => {
           app.make('product')
@@ -392,6 +396,8 @@ describe('mem-store tests', function () {
       describe('when a document/record in the upsert$ directive matches on a private field', () => {
         const app = makeSenecaForTest()
 
+        before(fin => app.ready(fin))
+
         beforeEach(fin => {
           app.make('product')
             .data$({ label: 'toothbrush', price: '3.95', psst$: 'private' })
@@ -436,6 +442,8 @@ describe('mem-store tests', function () {
       describe('when the upsert$ directive is empty', () => {
         const app = makeSenecaForTest()
 
+        before(fin => app.ready(fin))
+
         beforeEach(fin => {
           app.make('product')
             .data$({ label: 'toothbrush', price: '3.95' })
@@ -479,6 +487,8 @@ describe('mem-store tests', function () {
 
       describe('when a document/record in the upsert$ directive matches on an existing field set to undefined', () => {
         const app = makeSenecaForTest()
+
+        before(fin => app.ready(fin))
 
         beforeEach(fin => {
           app.make('product')
@@ -534,6 +544,8 @@ describe('mem-store tests', function () {
       describe('when a document/record in the upsert$ directive matches on an existing field set to null', () => {
         const app = makeSenecaForTest()
 
+        before(fin => app.ready(fin))
+
         beforeEach(fin => {
           app.make('product')
             .data$({ label: null, price: '3.95' })
@@ -584,6 +596,8 @@ describe('mem-store tests', function () {
       describe('when some of the fields in the data$/upsert$ directives do not exist in a document/record', () => {
         const app = makeSenecaForTest()
 
+        before(fin => app.ready(fin))
+
         beforeEach(fin => {
           app.make('product')
             .data$({ label: 'a toothbrush', price: '3.40' })
@@ -623,6 +637,8 @@ describe('mem-store tests', function () {
       describe('when some of the fields in the upsert$ directive do not exist in the attributes passed via data$', () => {
         const app = makeSenecaForTest()
 
+        before(fin => app.ready(fin))
+
         beforeEach(fin => {
           app.make('product')
             .data$({ label: 'a toothbrush', price: '3.40' })
@@ -661,6 +677,8 @@ describe('mem-store tests', function () {
     describe('when invoking upsert via the #save method of an existing entity', () => {
       describe('when some other existing documents/records in the upsert$ directive match', () => {
         const app = makeSenecaForTest()
+
+        before(fin => app.ready(fin))
 
 
         let existing_product

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -413,17 +413,61 @@ describe('mem-store tests', function () {
                   return fin(err)
                 }
 
-                console.log(products) // dbg
-                return fin() // dbg
+                expect(products.length).to.equal(2)
+
+                expect(products[0]).to.contain({
+                  label: 'toothbrush',
+                  price: '3.95'
+                })
+
+                expect(products[1]).to.contain({
+                  label: 'a new toothbrush',
+                  price: '5.95'
+                })
+
+                return fin()
+              })
+            })
+        })
+      })
+    })
+
+    describe('when the upsert$ directive is empty', () => {
+      const app = makeSenecaForTest()
+
+      beforeEach(fin => {
+        app.make('product')
+          .data$({ label: 'toothbrush', price: '3.95' })
+          .save$(fin)
+      })
+
+      it('creates a new document', fin => {
+        app.test(fin)
+
+        app.ready(() => {
+          app.make('product')
+            .data$({ label: 'toothbrush', price: '5.95' })
+            .save$({ upsert$: [] }, err => {
+              if (err) {
+                return fin(err)
+              }
+
+              app.make('product').list$({}, (err, products) => {
+                if (err) {
+                  return fin(err)
+                }
 
                 expect(products.length).to.equal(2)
 
-                /*
-                expect(products[1]).to.contain({
-                  label: 'CS101 textbook',
-                  price: '134.95'
+                expect(products[0]).to.contain({
+                  label: 'toothbrush',
+                  price: '3.95'
                 })
-                */
+
+                expect(products[1]).to.contain({
+                  label: 'toothbrush',
+                  price: '5.95'
+                })
 
                 return fin()
               })

--- a/test/mem.test.js
+++ b/test/mem.test.js
@@ -288,126 +288,251 @@ describe('mem-store tests', function () {
   describe('upsert', () => {
     describe('save$ invoked on a new entity instance', () => {
       describe('matching entity exists', () => {
-        const app = makeSenecaForTest()
+        describe('matches on 1 upsert$ field', () => {
+          const app = makeSenecaForTest()
 
-        before(fin => app.ready(fin))
+          before(fin => app.ready(fin))
 
-        beforeEach(fin => {
-          app.make('user')
-            .data$({ username: 'richard' })
-            .save$(fin)
-        })
-
-        beforeEach(fin => {
-          app.make('user')
-            .data$({ username: 'bob' })
-            .save$(fin)
-        })
-
-        it('updates the entity', fin => {
-          app.test(fin)
-
-          app.ready(() => {
+          beforeEach(fin => {
             app.make('user')
-              .data$({ username: 'richard', points: 9999 })
-              .save$({ upsert$: ['username'] }, err => {
-                if (err) {
-                  return fin(err)
-                }
+              .data$({ username: 'richard', points: 0 })
+              .save$(fin)
+          })
 
-                app.make('user').list$({}, (err, users) => {
+          beforeEach(fin => {
+            app.make('user')
+              .data$({ username: 'bob', points: 0 })
+              .save$(fin)
+          })
+
+          it('updates the entity', fin => {
+            app.test(fin)
+
+            app.ready(() => {
+              app.make('user')
+                .data$({ username: 'richard', points: 9999 })
+                .save$({ upsert$: ['username'] }, err => {
                   if (err) {
                     return fin(err)
                   }
 
-                  expect(users.length).to.equal(2)
+                  app.make('user').list$({}, (err, users) => {
+                    if (err) {
+                      return fin(err)
+                    }
+
+                    expect(users.length).to.equal(2)
 
 
-                  expect(users[0]).to.contain({
-                    username: 'richard',
-                    points: 9999
+                    expect(users[0]).to.contain({
+                      username: 'richard',
+                      points: 9999
+                    })
+
+
+                    expect(users[1]).to.contain({
+                      username: 'bob',
+                      points: 0
+                    })
+
+                    return fin()
                   })
-
-
-                  expect(users[1]).to.contain({
-                    username: 'bob'
-                  })
-
-                  expect(users[1]).to.not.contain('points')
-
-
-                  return fin()
                 })
-              })
+            })
+          })
+        })
+
+        describe('matches on 2 upsert$ fields', () => {
+          const app = makeSenecaForTest()
+
+          before(fin => app.ready(fin))
+
+          beforeEach(fin => {
+            app.make('user')
+              .data$({ username: 'richard', skill: 9999, points: 0 })
+              .save$(fin)
+          })
+
+          beforeEach(fin => {
+            app.make('user')
+              .data$({ username: 'bob', skill: 9999, points: 0 })
+              .save$(fin)
+          })
+
+          it('updates the entity', fin => {
+            app.test(fin)
+
+            app.ready(() => {
+              app.make('user')
+                .data$({ username: 'richard', skill: 9999, points: 1234 })
+                .save$({ upsert$: ['username', 'skill'] }, err => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  app.make('user').list$({}, (err, users) => {
+                    if (err) {
+                      return fin(err)
+                    }
+
+                    expect(users.length).to.equal(2)
+
+
+                    expect(users[0]).to.contain({
+                      username: 'richard',
+                      skill: 9999,
+                      points: 1234
+                    })
+
+
+                    expect(users[1]).to.contain({
+                      username: 'bob',
+                      skill: 9999,
+                      points: 0
+                    })
+
+
+                    return fin()
+                  })
+                })
+            })
           })
         })
       })
 
       describe('many matching entities exist', () => {
-        const app = makeSenecaForTest()
+        describe('matches on 1 upsert$ field', () => {
+          const app = makeSenecaForTest()
 
-        before(fin => app.ready(fin))
+          before(fin => app.ready(fin))
 
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'a toothbrush', price: '3.95' })
-            .save$(fin)
-        })
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'a toothbrush', price: '3.70' })
-            .save$(fin)
-        })
-
-        beforeEach(fin => {
-          app.make('product')
-            .data$({ label: 'bbs tires', price: '4.10' })
-            .save$(fin)
-        })
-
-        it('updates a single matching entity', fin => {
-          app.test(fin)
-
-          app.ready(() => {
+          beforeEach(fin => {
             app.make('product')
-              .data$({ label: 'a toothbrush', price: '4.95' })
-              .save$({ upsert$: ['label'] }, err => {
-                if (err) {
-                  return fin(err)
-                }
+              .data$({ label: 'a toothbrush', price: '3.95' })
+              .save$(fin)
+          })
 
-                app.make('product').list$({}, (err, products) => {
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'a toothbrush', price: '3.70' })
+              .save$(fin)
+          })
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'bbs tires', price: '4.10' })
+              .save$(fin)
+          })
+
+          it('updates a single matching entity', fin => {
+            app.test(fin)
+
+            app.ready(() => {
+              app.make('product')
+                .data$({ label: 'a toothbrush', price: '4.95' })
+                .save$({ upsert$: ['label'] }, err => {
                   if (err) {
                     return fin(err)
                   }
 
-                  expect(products.length).to.equal(3)
+                  app.make('product').list$({}, (err, products) => {
+                    if (err) {
+                      return fin(err)
+                    }
 
-                  expect(products[0]).to.contain({
-                    label: 'a toothbrush',
-                    price: '4.95'
+                    expect(products.length).to.equal(3)
+
+                    expect(products[0]).to.contain({
+                      label: 'a toothbrush',
+                      price: '4.95'
+                    })
+
+                    expect(products[1]).to.contain({
+                      label: 'a toothbrush',
+                      price: '3.70'
+                    })
+
+                    expect(products[2]).to.contain({
+                      label: 'bbs tires',
+                      price: '4.10'
+                    })
+
+                    return fin()
                   })
-
-                  expect(products[1]).to.contain({
-                    label: 'a toothbrush',
-                    price: '3.70'
-                  })
-
-                  expect(products[2]).to.contain({
-                    label: 'bbs tires',
-                    price: '4.10'
-                  })
-
-                  return fin()
                 })
-              })
+            })
+          })
+        })
+
+        describe('matches on 2 upsert$ fields', () => {
+          const app = makeSenecaForTest()
+
+          before(fin => app.ready(fin))
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'a toothbrush', price: '3.95', coolness_factor: 2 })
+              .save$(fin)
+          })
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'a toothbrush', price: '3.70', coolness_factor: 3 })
+              .save$(fin)
+          })
+
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'bbs tires', price: '4.10', coolness_factor: 7 })
+              .save$(fin)
+          })
+
+          it('updates a single matching entity', fin => {
+            app.test(fin)
+
+            app.ready(() => {
+              app.make('product')
+                .data$({ label: 'a toothbrush', price: '3.95', coolness_factor: 4 })
+                .save$({ upsert$: ['label', 'price'] }, err => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  app.make('product').list$({}, (err, products) => {
+                    if (err) {
+                      return fin(err)
+                    }
+
+                    expect(products.length).to.equal(3)
+
+                    expect(products[0]).to.contain({
+                      label: 'a toothbrush',
+                      price: '3.95',
+                      coolness_factor: 4
+                    })
+
+                    expect(products[1]).to.contain({
+                      label: 'a toothbrush',
+                      price: '3.70',
+                      coolness_factor: 3
+                    })
+
+                    expect(products[2]).to.contain({
+                      label: 'bbs tires',
+                      price: '4.10',
+                      coolness_factor: 7
+                    })
+
+                    return fin()
+                  })
+                })
+            })
           })
         })
       })
 
-      describe('no matching entities exist', () => {
-        describe('normally', () => {
+      describe('no matching entity exists', () => {
+        describe('1 upsert$ field', () => {
           const app = makeSenecaForTest()
 
           before(fin => app.ready(fin))
@@ -451,48 +576,98 @@ describe('mem-store tests', function () {
           })
         })
 
-        describe('bombarding the store with near-parallel upserts', () => {
+        describe('2 upsert$ fields', () => {
           const app = makeSenecaForTest()
 
           before(fin => app.ready(fin))
 
-          it('does not result in a race condition - creates a single new entity', fin => {
+          beforeEach(fin => {
+            app.make('product')
+              .data$({ label: 'frapuccino', price: '2.40', coolness_factor: 5 })
+              .save$(fin)
+          })
+
+          it('creates a new entity', fin => {
             app.test(fin)
 
-            const product_entity = app.entity('product')
-
-            const upsertProduct = cb => 
-              product_entity
-                .data$({ name: 'pencil', price: '1.95' })
-                .save$({ upsert$: ['name'] }, cb)
-
-
-            Async.parallel([
-              upsertProduct,
-              upsertProduct,
-              upsertProduct
-            ], err => {
-              if (err) {
-                return fin(err)
-              }
-
-              product_entity.list$((err, products) => {
+            app.make('product')
+              .data$({ label: 'frapuccino', price: '3.40', coolness_factor: 7 })
+              .save$({ upsert$: ['label', 'price'] }, err => {
                 if (err) {
                   return fin(err)
                 }
 
-                expect(products.length).to.equal(1)
+                app.make('product').list$({}, (err, products) => {
+                  if (err) {
+                    return fin(err)
+                  }
 
-                expect(products[0]).to.contain({
-                  name: 'pencil',
-                  price: '1.95'
+                  expect(products.length).to.equal(2)
+
+                  expect(products[0]).to.contain({
+                    label: 'frapuccino',
+                    price: '2.40',
+                    coolness_factor: 5
+                  })
+
+                  expect(products[1]).to.contain({
+                    label: 'frapuccino',
+                    price: '3.40',
+                    coolness_factor: 7
+                  })
+
+                  return fin()
+                })
+              })
+          })
+        })
+
+        describe('edge cases', () => {
+          describe('bombarding the store with near-parallel upserts', () => {
+            describe('1 upsert$ field', () => {
+              const app = makeSenecaForTest()
+
+              before(fin => app.ready(fin))
+
+              it('does not result in a race condition - creates a single new entity', fin => {
+                app.test(fin)
+
+                const product_entity = app.entity('product')
+
+                const upsertProduct = cb => 
+                  product_entity
+                    .data$({ name: 'pencil', price: '1.95' })
+                    .save$({ upsert$: ['name'] }, cb)
+
+
+                Async.parallel([
+                  upsertProduct,
+                  upsertProduct,
+                  upsertProduct
+                ], err => {
+                  if (err) {
+                    return fin(err)
+                  }
+
+                  product_entity.list$((err, products) => {
+                    if (err) {
+                      return fin(err)
+                    }
+
+                    expect(products.length).to.equal(1)
+
+                    expect(products[0]).to.contain({
+                      name: 'pencil',
+                      price: '1.95'
+                    })
+
+                    return fin()
+                  })
                 })
 
-                return fin()
+                return
               })
             })
-
-            return
           })
         })
       })


### PR DESCRIPTION
Example usage (assuming the promisifying plugin is plugged in):
```
await Seneca
    .make(‘foo’)
    .data$({ x: 1, y: 2 })
    .save$({ upsert$: [‘x’] })
```

Questions:
- [ ] Where may I add documentation to explain the feature?
- [ ] Do we ignore the `upsert$` directive when the `#save$` method is being invoked on an existing entity? E.g.:
```
const existing_foo = await Seneca.make('foo').load$(foo_id);

Assert(existing_foo, 'existing_foo');

await existing_foo
    .data$({ x: 1, y: 2 })
    .save$({ upsert$: [‘x’] })
```

P.S. I believe the next step could be additional behavior testing of the features (such as, e.g., insertion, update, etc.) in order to probe for all possible edge cases and such.

